### PR TITLE
Adds a Password Text feild for signIn & signUp screens

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -58,6 +58,7 @@ dependencies {
     implementation(platform(libs.androidx.compose.bom))
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
+    implementation (libs.androidx.material.icons.extended)
     implementation(libs.androidx.ui.tooling.preview)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.ui.text.google.fonts)

--- a/app/src/main/java/com/example/photonest/MainActivity.kt
+++ b/app/src/main/java/com/example/photonest/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -48,6 +49,7 @@ import com.example.photonest.ui.components.Heading2
 import com.example.photonest.ui.components.NormalText
 import com.example.photonest.ui.components.OnBoardingTextField
 import com.example.photonest.ui.components.OnboardingCircleBtn
+import com.example.photonest.ui.components.ShowHidePasswordTextField
 import com.example.photonest.ui.components.SignSocialButtons
 import com.example.photonest.ui.components.annotatedText
 import com.example.photonest.ui.screens.splash.SplashAndMain
@@ -76,6 +78,8 @@ class MainActivity : ComponentActivity() {
                     NormalText(text = "Create an account")
                     Text(text = annotatedText(text1 = "Create an", text2 = "account"))
                     AnnotatedText(text1 = "Create an", text2 = "account")
+                    ShowHidePasswordTextField(label = "Password", modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth())
+                    ShowHidePasswordTextField(label = "Confirm Password", modifier = Modifier.padding(horizontal = 16.dp).fillMaxWidth())
                 }
             }
         }

--- a/app/src/main/java/com/example/photonest/ui/components/Textfield.kt
+++ b/app/src/main/java/com/example/photonest/ui/components/Textfield.kt
@@ -1,5 +1,6 @@
 package com.example.photonest.ui.components
 
+import androidx.annotation.DrawableRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -7,8 +8,12 @@ import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsFocusedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.defaultMinSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -20,20 +25,38 @@ import androidx.compose.foundation.text.input.TextFieldState
 import androidx.compose.foundation.text.input.rememberTextFieldState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
+import androidx.compose.material.icons.outlined.Lock
 import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextFieldColors
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusModifier
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.compose.grey
+import com.example.compose.light_grey
+import com.example.compose.nickel
 import com.example.photonest.ui.theme.fontFamily
 import com.example.photonest.ui.theme.fontName
 
@@ -123,4 +146,93 @@ fun OnBoardingTextField(
             lineHeight = 25.sp
         )
     )
+}
+
+@Composable
+fun ShowHidePasswordTextField(
+    label: String,
+    modifier: Modifier = Modifier,
+    password: MutableState<String> =  mutableStateOf(value = ""),
+) {
+    var showPassword by remember { mutableStateOf(value = false) }
+    Column (
+        modifier = modifier
+    ){
+        Text(
+            text = label,
+            style = TextStyle(
+                fontSize = 14.sp,
+                fontFamily = fontFamily,
+                lineHeight = 22.sp,
+                fontWeight = FontWeight.Medium,
+                color = nickel
+            ),
+            modifier = Modifier.padding(start = 5.dp)
+        )
+
+        OutlinedTextField(
+            modifier = Modifier.fillMaxWidth().defaultMinSize(minHeight = 54.dp),
+            value = password.value,
+            onValueChange = { newText ->
+                password.value = newText
+            },
+            leadingIcon = {
+                Icon(
+                    imageVector = Icons.Outlined.Lock,
+                    contentDescription = "hide_password",
+                )
+            },
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedLeadingIconColor = nickel,
+                unfocusedLeadingIconColor = light_grey,
+                unfocusedBorderColor = light_grey,
+                focusedBorderColor = nickel,
+                unfocusedTextColor = light_grey,
+                focusedTextColor = nickel,
+                focusedPlaceholderColor = nickel,
+                unfocusedPlaceholderColor = light_grey,
+                cursorColor = nickel,
+                focusedLabelColor = nickel,
+                disabledLabelColor = light_grey,
+                disabledTrailingIconColor = light_grey,
+                focusedTrailingIconColor = nickel
+            ),
+            placeholder = {
+                Text(
+                    text = label,
+                    style = TextStyle(
+                        fontSize = 16.sp,
+                        fontFamily = fontFamily,
+                        lineHeight = 25.sp,
+                        fontWeight = FontWeight.Medium),
+                )
+            },
+            shape = RoundedCornerShape(percent = 20),
+            visualTransformation = if (showPassword) {
+                VisualTransformation.None
+            } else {
+                PasswordVisualTransformation()
+            },
+            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Password),
+            trailingIcon = {
+                if (showPassword) {
+                    IconButton(onClick = { showPassword = false }) {
+                        Icon(
+                            imageVector = Icons.Filled.Visibility,
+                            contentDescription = "hide_password",
+                        )
+                    }
+                } else {
+                    IconButton(
+                        onClick = { showPassword = true }) {
+                        Icon(
+                            imageVector = Icons.Filled.VisibilityOff,
+                            contentDescription = "hide_password"
+                        )
+                    }
+                }
+            }
+        )
+    }
+    
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,11 +9,13 @@ espressoCore = "3.5.1"
 lifecycleRuntimeKtx = "2.6.1"
 activityCompose = "1.8.0"
 composeBom = "2024.04.01"
+materialIconsExtended = "1.7.4"
 uiTextGoogleFonts = "1.7.3"
 
 [libraries]
 androidx-core-ktx = { group = "androidx.core", name = "core-ktx", version.ref = "coreKtx" }
 androidx-foundation = { module = "androidx.compose.foundation:foundation", version.ref = "foundation" }
+androidx-material-icons-extended = { module = "androidx.compose.material:material-icons-extended", version.ref = "materialIconsExtended" }
 junit = { group = "junit", name = "junit", version.ref = "junit" }
 androidx-junit = { group = "androidx.test.ext", name = "junit", version.ref = "junitVersion" }
 androidx-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "espressoCore" }


### PR DESCRIPTION
**Title:** Add Password Text Field Component

**Description:**

This pull request introduces a reusable password text field component with a visibility toggle. It includes password masking using `VisualTransformation`. The component has not been integrated into any screens yet.
