### PR TITLE
Screens/signin

### DIFF
--- a/app/src/main/java/com/example/photonest/ui/components/AlertDialog.kt
+++ b/app/src/main/java/com/example/photonest/ui/components/AlertDialog.kt
@@ -1,0 +1,102 @@
+package com.example.photonest.ui.components
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.ButtonColors
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Devices
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.example.photonest.ui.theme.PhotoNestTheme
+
+@Composable
+fun MyAlertDialog(
+    modifier: Modifier = Modifier,
+    shouldShowDialog: Boolean,
+    onDismissRequest: () -> Unit,
+    title: String,
+    text: String,
+    confirmButtonText: String,
+    onConfirmClick: () -> Unit,
+    dismissButtonText: String? = null,
+    onDismissClick: (() -> Unit)? = null,
+) {
+    if (shouldShowDialog) {
+        AlertDialog(
+            modifier = modifier,
+            onDismissRequest = onDismissRequest,
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+            title = {
+                Heading2(
+                    text = title,
+                    fontSize = 24.sp,
+                    lineHeight = 28.sp,
+                    textAlign = TextAlign.Center
+                )
+            },
+            text = {
+                NormalText(
+                    text = text,
+                    fontColor = MaterialTheme.colorScheme.onSurface,
+                    textAlign = TextAlign.Left
+                )
+            },
+            confirmButton = {
+                ButtonOnboarding(
+                    buttonText = confirmButtonText,
+                    onClick = onConfirmClick,
+                    shape = RoundedCornerShape(8.dp),
+                    )
+            },
+            dismissButton = dismissButtonText?.let {
+                {
+                    ButtonOnboarding(
+                        buttonColors = ButtonColors(
+                            containerColor = MaterialTheme.colorScheme.errorContainer,
+                            contentColor = MaterialTheme.colorScheme.onErrorContainer,
+                            disabledContainerColor = MaterialTheme.colorScheme.errorContainer,
+                            disabledContentColor = MaterialTheme.colorScheme.onErrorContainer
+                        ),
+                        shape = RoundedCornerShape(8.dp),
+                        buttonText = it,
+                        onClick = onDismissClick ?: onDismissRequest
+                    )
+                }
+            }
+        )
+    }
+}
+
+//@SuppressLint("UnrememberedMutableState")
+//@Preview(
+//    showBackground = true,
+//    showSystemUi = true
+//)
+//@Composable
+//private fun Prev() {
+//    PhotoNestTheme {
+//        Box(
+//            modifier = Modifier.fillMaxSize(),
+//            contentAlignment = Alignment.Center
+//        ){
+//            MyAlertDialog(
+//                title = "Alert Dialog",
+//                shouldShowDialog = true,
+//                dismissButtonText = "Close",
+//                onDismissRequest = {},
+//                text = "This is a custom error.This is a custom error.This is a custom error.This is a custom error.",
+//                confirmButtonText = "Continue",
+//                onConfirmClick = {}
+//            )
+//        }
+//    }
+//}

--- a/app/src/main/java/com/example/photonest/ui/components/Buttons.kt
+++ b/app/src/main/java/com/example/photonest/ui/components/Buttons.kt
@@ -1,5 +1,6 @@
 package com.example.photonest.ui.components
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
@@ -19,6 +20,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.IconButtonColors
 import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -26,10 +28,13 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.photonest.R
@@ -41,12 +46,14 @@ fun ButtonOnboarding(
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
     enabled: Boolean = true,
+    shape: Shape = RoundedCornerShape(12.dp),
+    textSize: TextUnit = 16.sp,
     textColor: Color = MaterialTheme.colorScheme.onPrimaryContainer,
     buttonColors: ButtonColors = ButtonDefaults.buttonColors(
         containerColor = MaterialTheme.colorScheme.primaryContainer,
         disabledContainerColor = MaterialTheme.colorScheme.primaryContainer.copy(0.4f)
     ),
-    elevation: ButtonElevation = ButtonDefaults.buttonElevation(5.dp),
+    elevation: ButtonElevation = ButtonDefaults.buttonElevation(4.dp),
     prefixIcon: @Composable () -> Unit? = { null }
 ) {
     Button(
@@ -54,7 +61,7 @@ fun ButtonOnboarding(
         enabled = enabled,
         onClick = onClick,
         colors = buttonColors,
-        shape = RoundedCornerShape(12.dp),
+        shape = shape,
         elevation = elevation
     ) {
         Row(
@@ -69,7 +76,7 @@ fun ButtonOnboarding(
                 color = textColor,
                 fontWeight = FontWeight.SemiBold,
                 fontFamily = bodyFontFamily,
-                fontSize = 16.sp
+                fontSize = textSize
             )
         }
     }

--- a/app/src/main/java/com/example/photonest/ui/components/Texts.kt
+++ b/app/src/main/java/com/example/photonest/ui/components/Texts.kt
@@ -17,7 +17,10 @@ import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.example.photonest.ui.theme.bodyFontFamily
@@ -26,6 +29,7 @@ import com.example.photonest.ui.theme.bodyFontFamily
 fun Heading1(
     modifier: Modifier = Modifier,
     text: String,
+    textAlign: TextAlign = TextAlign.Left,
     fontWeight: FontWeight = FontWeight.SemiBold,
     fontColor: Color = MaterialTheme.colorScheme.primary,
     textDecoration: TextDecoration = TextDecoration.None
@@ -37,7 +41,8 @@ fun Heading1(
             lineHeight = 48.sp,
             fontWeight = fontWeight,
             textDecoration = textDecoration,
-            color = fontColor
+            color = fontColor,
+            textAlign = textAlign
         ), modifier = modifier
     )
 }
@@ -45,19 +50,23 @@ fun Heading1(
 @Composable
 fun Heading2(
     modifier: Modifier = Modifier,
+    fontSize: TextUnit = 32.sp,
     text: String,
+    textAlign: TextAlign = TextAlign.Left,
     fontWeight: FontWeight = FontWeight.SemiBold,
+    lineHeight: TextUnit = 54.sp,
     fontColor: Color = MaterialTheme.colorScheme.primary,
     textDecoration: TextDecoration = TextDecoration.None
 ) {
     Text(
         text = text, style = TextStyle(
-            fontSize = 32.sp,
+            fontSize = fontSize,
             fontFamily = bodyFontFamily,
-            lineHeight = 54.sp,
+            lineHeight = lineHeight,
             fontWeight = fontWeight,
             textDecoration = textDecoration,
-            color = fontColor
+            color = fontColor,
+            textAlign = textAlign
         ), modifier = modifier
     )
 }
@@ -66,6 +75,7 @@ fun Heading2(
 fun NormalText(
     modifier: Modifier = Modifier,
     text: String,
+    textAlign: TextAlign = TextAlign.Left,
     fontWeight: FontWeight = FontWeight.Medium,
     fontColor: Color = MaterialTheme.colorScheme.onBackground,
     textDecoration: TextDecoration = TextDecoration.None
@@ -77,7 +87,8 @@ fun NormalText(
             lineHeight = 25.sp,
             fontWeight = fontWeight,
             textDecoration = textDecoration,
-            color = fontColor
+            color = fontColor,
+            textAlign = textAlign
         ), modifier = modifier
     )
 }

--- a/app/src/main/java/com/example/photonest/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/photonest/ui/navigation/AppNavigation.kt
@@ -13,6 +13,7 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import com.example.photonest.ui.screens.OtpScreen
+import com.example.photonest.ui.screens.signin.SignInScreen
 import com.example.photonest.ui.screens.signup.SignUpScreen
 import com.example.photonest.ui.screens.splash.SplashScreen
 
@@ -40,6 +41,18 @@ fun AppNavigation(
         composable(AppDestinations.SIGN_UP_ROUTE) {
             SignUpScreen(
                 onSignUpSuccess = { navController.navigate(AppDestinations.OTP_ROUTE) },
+                onBackClick = { navController.popBackStack() },
+                onSignInTxtClick = {navController.navigate(AppDestinations.SIGN_IN_ROUTE) },
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.background)
+                    .padding(horizontal = 16.dp)
+                    .fillMaxSize()
+                    .safeContentPadding()
+            )
+        }
+        composable(AppDestinations.SIGN_IN_ROUTE) {
+            SignInScreen(
+                onSignInSuccess = { navController.navigate(AppDestinations.OTP_ROUTE) },
                 onBackClick = { navController.popBackStack() },
                 modifier = Modifier
                     .background(MaterialTheme.colorScheme.background)

--- a/app/src/main/java/com/example/photonest/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/photonest/ui/navigation/AppNavigation.kt
@@ -54,6 +54,7 @@ fun AppNavigation(
             SignInScreen(
                 onSignInSuccess = { navController.navigate(AppDestinations.OTP_ROUTE) },
                 onBackClick = { navController.popBackStack() },
+                onSignUpTxtClick = {navController.navigate(AppDestinations.SIGN_UP_ROUTE)},
                 modifier = Modifier
                     .background(MaterialTheme.colorScheme.background)
                     .padding(horizontal = 16.dp)

--- a/app/src/main/java/com/example/photonest/ui/screens/signin/SignInScreen.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signin/SignInScreen.kt
@@ -1,5 +1,7 @@
 package com.example.photonest.ui.screens.signin
 
+import SignInUiState
+import SignInViewModel
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -12,12 +14,20 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.example.photonest.R
 import com.example.photonest.ui.components.AnnotatedText
 import com.example.photonest.ui.components.BackTxtBtn
@@ -28,28 +38,45 @@ import com.example.photonest.ui.components.OnBoardingTextField
 import com.example.photonest.ui.components.OnboardingCircleBtn
 import com.example.photonest.ui.components.ShowHidePasswordTextField
 import com.example.photonest.ui.components.SignSocialButtons
+import com.example.photonest.ui.screens.signup.SignUpViewModel
 import com.example.photonest.ui.theme.PhotoNestTheme
+import com.example.photonest.ui.theme.bodyFontFamily
 
 @Composable
 fun SignInScreen(
-    onSignInSuccess: () -> Unit,
     modifier: Modifier = Modifier,
+    viewModel: SignInViewModel = viewModel(),
+    onSignInSuccess: () -> Unit,
+    onSignUpTxtClick: () -> Unit,
     onBackClick: () -> Boolean,
 ) {
+    val uiState by viewModel.uiState.collectAsState()
+
     SignInContent(
-        onEmailChange = {},
-        onPasswordChange = {},
+        uiState = uiState,
+        onEmailChange = viewModel::updateEmail,
+        onPasswordChange = viewModel::updatePassword,
+        onSignInTxtClick = {onSignUpTxtClick()},
+        onSignInClick = {viewModel.signIn()},
         onBackClick = onBackClick,
+        onSignInSuccess = onSignInSuccess,
         modifier = modifier
     )
+    if (uiState.isSignInSuccessful) {
+        LaunchedEffect(Unit) {
+            onSignInSuccess()
+        }
+    }
 }
 
 @Composable
 fun SignInContent(
     modifier: Modifier = Modifier,
+    uiState: SignInUiState,
     onEmailChange: (String) -> Unit,
     onPasswordChange: (String) -> Unit,
     onSignInClick: () -> Unit = {},
+    onSignInTxtClick: () -> Unit,
     onBackClick: () -> Boolean,
     onSignInSuccess: () -> Unit = {},
 ) {
@@ -73,11 +100,22 @@ fun SignInContent(
                 verticalArrangement = Arrangement.spacedBy(16.dp)
             ){
                 OnBoardingTextField(
-                    value = "",
+                    value = uiState.email,
                     onValueChange = onEmailChange,
                     label = "Email",
-                    isError = false,
-                    errorMessage = {},
+                    isError = uiState.emailError != null,
+                    errorMessage = {
+                        Text(
+                            text = uiState.emailError?: "",
+                            style = TextStyle(
+                                fontSize = 14.sp,
+                                fontFamily = bodyFontFamily,
+                                lineHeight = 22.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        )
+                    },
                     prefix = {
                         Icon(
                             painter = painterResource(id = R.drawable.user_logo),
@@ -88,10 +126,21 @@ fun SignInContent(
                 )
                 ShowHidePasswordTextField(
                     label = "Password",
-                    value = "",
+                    value = uiState.password,
                     onValueChange = onPasswordChange,
-                    isError = false,
-                    errorMessage = { },
+                    isError = uiState.passwordError != null,
+                    errorMessage = {
+                        Text(
+                            text = uiState.passwordError?: "",
+                            style = TextStyle(
+                                fontSize = 14.sp,
+                                fontFamily = bodyFontFamily,
+                                lineHeight = 22.sp,
+                                fontWeight = FontWeight.Medium,
+                                color = MaterialTheme.colorScheme.error
+                            )
+                        )
+                    },
                 )
                 Row (
                     modifier = Modifier.fillMaxWidth(),
@@ -99,7 +148,7 @@ fun SignInContent(
                     horizontalArrangement = Arrangement.SpaceBetween
                 ){
                     AnnotatedText(
-                        text1 = "Don't have an account.", text2 = "Sign Up",
+                        text1 = "Don't have an account.", text2 = "Sign Up", onClickTxt2 = {onSignInTxtClick()},
                         modifier = Modifier.height(24.dp)
                     )
                     AnnotatedText(
@@ -119,7 +168,7 @@ fun SignInContent(
                 Heading2(text = "Continue", fontColor = MaterialTheme.colorScheme.onBackground)
                 OnboardingCircleBtn(
                     onClick = { onSignInClick() },
-                    enabled = true
+                    enabled = uiState.isInputValid && !uiState.isLoading
                 )
             }
         }
@@ -138,17 +187,17 @@ fun SignInContent(
     }
 }
 
-@Preview(showBackground = true, showSystemUi = true)
-@Composable
-private fun SignInPrev() {
-    PhotoNestTheme {
-        SignInContent(
-            onEmailChange = {},
-            onPasswordChange = {},
-            onBackClick = {false},
-            modifier = Modifier
-                .fillMaxSize()
-                .padding(16.dp)
-        )
-    }
-}
+//@Preview(showBackground = true, showSystemUi = true)
+//@Composable
+//private fun SignInPrev() {
+//    PhotoNestTheme {
+//        SignInContent(
+//            onEmailChange = {},
+//            onPasswordChange = {},
+//            onBackClick = {false},
+//            modifier = Modifier
+//                .fillMaxSize()
+//                .padding(16.dp)
+//        )
+//    }
+//}

--- a/app/src/main/java/com/example/photonest/ui/screens/signin/SignInScreen.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signin/SignInScreen.kt
@@ -1,0 +1,154 @@
+package com.example.photonest.ui.screens.signin
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.example.photonest.R
+import com.example.photonest.ui.components.AnnotatedText
+import com.example.photonest.ui.components.BackTxtBtn
+import com.example.photonest.ui.components.Heading1
+import com.example.photonest.ui.components.Heading2
+import com.example.photonest.ui.components.NormalText
+import com.example.photonest.ui.components.OnBoardingTextField
+import com.example.photonest.ui.components.OnboardingCircleBtn
+import com.example.photonest.ui.components.ShowHidePasswordTextField
+import com.example.photonest.ui.components.SignSocialButtons
+import com.example.photonest.ui.theme.PhotoNestTheme
+
+@Composable
+fun SignInScreen(
+    onSignInSuccess: () -> Unit,
+    modifier: Modifier = Modifier,
+    onBackClick: () -> Boolean,
+) {
+    SignInContent(
+        onEmailChange = {},
+        onPasswordChange = {},
+        onBackClick = onBackClick,
+        modifier = modifier
+    )
+}
+
+@Composable
+fun SignInContent(
+    modifier: Modifier = Modifier,
+    onEmailChange: (String) -> Unit,
+    onPasswordChange: (String) -> Unit,
+    onSignInClick: () -> Unit = {},
+    onBackClick: () -> Boolean,
+    onSignInSuccess: () -> Unit = {},
+) {
+    LazyColumn(
+        modifier = modifier,
+        verticalArrangement = Arrangement.spacedBy(40.dp),
+        horizontalAlignment = Alignment.Start
+    ) {
+        item {
+            Row (
+                verticalAlignment = Alignment.Top,
+                horizontalArrangement = Arrangement.SpaceBetween,
+                modifier = Modifier.fillMaxWidth()
+            ){
+                Heading1(text = "Let's sign in", fontColor = MaterialTheme.colorScheme.primary)
+                BackTxtBtn(onClick = { onBackClick() }, modifier = Modifier.padding(top = 12.dp))
+            }
+        }
+        item {
+            Column (
+                verticalArrangement = Arrangement.spacedBy(16.dp)
+            ){
+                OnBoardingTextField(
+                    value = "",
+                    onValueChange = onEmailChange,
+                    label = "Email",
+                    isError = false,
+                    errorMessage = {},
+                    prefix = {
+                        Icon(
+                            painter = painterResource(id = R.drawable.user_logo),
+                            contentDescription = null,
+                            modifier = Modifier.size(20.dp)
+                        )
+                    }
+                )
+                ShowHidePasswordTextField(
+                    label = "Password",
+                    value = "",
+                    onValueChange = onPasswordChange,
+                    isError = false,
+                    errorMessage = { },
+                )
+                Row (
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                    horizontalArrangement = Arrangement.SpaceBetween
+                ){
+                    AnnotatedText(
+                        text1 = "Don't have an account.", text2 = "Sign Up",
+                        modifier = Modifier.height(24.dp)
+                    )
+                    AnnotatedText(
+                        text1 = "", text2 = "Forgot Password?",
+                        modifier = Modifier.height(24.dp)
+                    )
+                }
+            }
+        }
+
+        item {
+            Row (
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceBetween
+            ){
+                Heading2(text = "Continue", fontColor = MaterialTheme.colorScheme.onBackground)
+                OnboardingCircleBtn(
+                    onClick = { onSignInClick() },
+                    enabled = true
+                )
+            }
+        }
+
+        item {
+            Column(
+                modifier = Modifier.fillMaxWidth(),
+                verticalArrangement = Arrangement.Center,
+                horizontalAlignment = Alignment.CenterHorizontally
+            ) {
+                NormalText(text = "Sign In With")
+                Spacer(modifier = Modifier.height(10.dp))
+                SignSocialButtons()
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true, showSystemUi = true)
+@Composable
+private fun SignInPrev() {
+    PhotoNestTheme {
+        SignInContent(
+            onEmailChange = {},
+            onPasswordChange = {},
+            onBackClick = {false},
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        )
+    }
+}

--- a/app/src/main/java/com/example/photonest/ui/screens/signin/SignInScreen.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signin/SignInScreen.kt
@@ -3,6 +3,7 @@ package com.example.photonest.ui.screens.signin
 import SignInUiState
 import SignInViewModel
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +13,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -52,20 +54,23 @@ fun SignInScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    SignInContent(
-        uiState = uiState,
-        onEmailChange = viewModel::updateEmail,
-        onPasswordChange = viewModel::updatePassword,
-        onSignInTxtClick = {onSignUpTxtClick()},
-        onSignInClick = {viewModel.signIn()},
-        onBackClick = onBackClick,
-        onSignInSuccess = onSignInSuccess,
-        modifier = modifier
-    )
+
     if (uiState.isSignInSuccessful) {
         LaunchedEffect(Unit) {
             onSignInSuccess()
+            viewModel.resetError()
         }
+    }else{
+        SignInContent(
+            uiState = uiState,
+            onEmailChange = viewModel::updateEmail,
+            onPasswordChange = viewModel::updatePassword,
+            onSignInTxtClick = {onSignUpTxtClick()},
+            onSignInClick = {viewModel.signIn()},
+            onBackClick = onBackClick,
+            onSignInSuccess = onSignInSuccess,
+            modifier = modifier
+        )
     }
 }
 
@@ -183,6 +188,14 @@ fun SignInContent(
                 Spacer(modifier = Modifier.height(10.dp))
                 SignSocialButtons()
             }
+        }
+    }
+    if (uiState.isLoading) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            CircularProgressIndicator()
         }
     }
 }

--- a/app/src/main/java/com/example/photonest/ui/screens/signin/SignInScreen.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signin/SignInScreen.kt
@@ -35,6 +35,7 @@ import com.example.photonest.ui.components.AnnotatedText
 import com.example.photonest.ui.components.BackTxtBtn
 import com.example.photonest.ui.components.Heading1
 import com.example.photonest.ui.components.Heading2
+import com.example.photonest.ui.components.MyAlertDialog
 import com.example.photonest.ui.components.NormalText
 import com.example.photonest.ui.components.OnBoardingTextField
 import com.example.photonest.ui.components.OnboardingCircleBtn
@@ -55,23 +56,31 @@ fun SignInScreen(
     val uiState by viewModel.uiState.collectAsState()
 
 
-    if (uiState.isSignInSuccessful) {
-        LaunchedEffect(Unit) {
+    LaunchedEffect(uiState.isSignInSuccessful) {
+        if (uiState.isSignInSuccessful) {
             onSignInSuccess()
             viewModel.resetError()
         }
-    }else{
-        SignInContent(
-            uiState = uiState,
-            onEmailChange = viewModel::updateEmail,
-            onPasswordChange = viewModel::updatePassword,
-            onSignInTxtClick = {onSignUpTxtClick()},
-            onSignInClick = {viewModel.signIn()},
-            onBackClick = onBackClick,
-            onSignInSuccess = onSignInSuccess,
-            modifier = modifier
-        )
     }
+
+    SignInContent(
+        uiState = uiState,
+        onEmailChange = viewModel::updateEmail,
+        onPasswordChange = viewModel::updatePassword,
+        onSignInTxtClick = onSignUpTxtClick,
+        onSignInClick = viewModel::signIn,
+        onBackClick = onBackClick,
+        modifier = modifier
+    )
+
+    MyAlertDialog(
+        shouldShowDialog = uiState.showErrorDialog,
+        onDismissRequest = viewModel::dismissErrorDialog,
+        title = "Sign In Failed",
+        text = uiState.error ?: "An unknown error occurred",
+        confirmButtonText = "OK",
+        onConfirmClick = viewModel::dismissErrorDialog
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/example/photonest/ui/screens/signin/SignInViewModel.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signin/SignInViewModel.kt
@@ -1,0 +1,81 @@
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.google.firebase.auth.FirebaseAuth
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.tasks.await
+
+class SignInViewModel : ViewModel() {
+    private val auth: FirebaseAuth = FirebaseAuth.getInstance()
+    private val _uiState = MutableStateFlow(SignInUiState())
+    val uiState: StateFlow<SignInUiState> = _uiState
+
+    private var hasInteractedWithEmail = false
+    private var hasInteractedWithPassword = false
+
+    fun updateEmail(email: String) {
+        hasInteractedWithEmail = true
+        _uiState.update { it.copy(email = email) }
+        validateInput()
+    }
+
+    fun updatePassword(password: String) {
+        hasInteractedWithPassword = true
+        _uiState.update { it.copy(password = password) }
+        validateInput()
+    }
+
+    fun signIn() {
+        val currentState = _uiState.value
+
+        viewModelScope.launch {
+            try {
+                _uiState.update { it.copy(isLoading = true, error = null) }
+
+                auth.signInWithEmailAndPassword(currentState.email, currentState.password).await()
+
+                _uiState.update { it.copy(isLoading = false, isSignInSuccessful = true) }
+            } catch (e: Exception) {
+                _uiState.update {
+                    it.copy(
+                        isLoading = false,
+                        error = e.message ?: "An error occurred during sign in"
+                    )
+                }
+            }
+        }
+    }
+
+    fun resetError() {
+        _uiState.update { it.copy(error = null) }
+    }
+
+    private fun validateInput() {
+        val email = _uiState.value.email
+        val password = _uiState.value.password
+
+        val isEmailValid = if (hasInteractedWithEmail) android.util.Patterns.EMAIL_ADDRESS.matcher(email).matches() else true
+        val isPasswordValid = if (hasInteractedWithPassword) password.isNotEmpty() else true
+
+        _uiState.update {
+            it.copy(
+                isInputValid = isEmailValid && isPasswordValid,
+                emailError = if (hasInteractedWithEmail && !isEmailValid) "Invalid email address" else null,
+                passwordError = if (hasInteractedWithPassword && !isPasswordValid) "Password cannot be empty" else null
+            )
+        }
+    }
+}
+
+data class SignInUiState(
+    val email: String = "",
+    val password: String = "",
+    val isLoading: Boolean = false,
+    val isInputValid: Boolean = false,
+    val isSignInSuccessful: Boolean = false,
+    val error: String? = null,
+    val emailError: String? = null,
+    val passwordError: String? = null
+)

--- a/app/src/main/java/com/example/photonest/ui/screens/signin/SignInViewModel.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signin/SignInViewModel.kt
@@ -41,11 +41,16 @@ class SignInViewModel : ViewModel() {
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        error = e.message ?: "An error occurred during sign in"
+                        error = e.message ?: "An error occurred during sign in",
+                        showErrorDialog = true
                     )
                 }
             }
         }
+    }
+
+    fun dismissErrorDialog() {
+        _uiState.update { it.copy(showErrorDialog = false) }
     }
 
     fun resetError() {
@@ -77,5 +82,6 @@ data class SignInUiState(
     val isSignInSuccessful: Boolean = false,
     val error: String? = null,
     val emailError: String? = null,
-    val passwordError: String? = null
+    val passwordError: String? = null,
+    val showErrorDialog: Boolean = false
 )

--- a/app/src/main/java/com/example/photonest/ui/screens/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signup/SignUpScreen.kt
@@ -32,6 +32,7 @@ import com.example.photonest.ui.components.AnnotatedText
 import com.example.photonest.ui.components.BackTxtBtn
 import com.example.photonest.ui.components.Heading1
 import com.example.photonest.ui.components.Heading2
+import com.example.photonest.ui.components.MyAlertDialog
 import com.example.photonest.ui.components.NormalText
 import com.example.photonest.ui.components.OnBoardingTextField
 import com.example.photonest.ui.components.OnboardingCircleBtn
@@ -52,21 +53,29 @@ fun SignUpScreen(
     if (uiState.isSignUpSuccessful) {
         LaunchedEffect(Unit) {
             onSignUpSuccess()
+            viewModel.resetError()
         }
-    }else{
-        SignUpContent(
-            uiState = uiState,
-            onEmailChange = viewModel::updateEmail,
-            onUsernameChange = viewModel::updateUsername,
-            onPasswordChange = viewModel::updatePassword,
-            onConfirmPasswordChange = viewModel::updateConfirmPassword,
-            onSignUpClick = {viewModel.signUp()},
-            onSignInTxtClick = {onSignInTxtClick()},
-            onBackClick = onBackClick,
-            onSignUpSuccess = onSignUpSuccess,
-            modifier = modifier
-        )
     }
+    SignUpContent(
+        uiState = uiState,
+        onEmailChange = viewModel::updateEmail,
+        onUsernameChange = viewModel::updateUsername,
+        onPasswordChange = viewModel::updatePassword,
+        onConfirmPasswordChange = viewModel::updateConfirmPassword,
+        onSignUpClick = {viewModel.signUp()},
+        onSignInTxtClick = {onSignInTxtClick()},
+        onBackClick = onBackClick,
+        onSignUpSuccess = onSignUpSuccess,
+        modifier = modifier
+    )
+    MyAlertDialog(
+        shouldShowDialog = uiState.showErrorDialog,
+        onDismissRequest = viewModel::dismissErrorDialog,
+        title = "Sign Up Failed",
+        text = uiState.error ?: "An unknown error occurred",
+        confirmButtonText = "OK",
+        onConfirmClick = viewModel::dismissErrorDialog
+    )
 }
 
 @Composable

--- a/app/src/main/java/com/example/photonest/ui/screens/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signup/SignUpScreen.kt
@@ -49,23 +49,23 @@ fun SignUpScreen(
 ) {
     val uiState by viewModel.uiState.collectAsState()
 
-    SignUpContent(
-        uiState = uiState,
-        onEmailChange = viewModel::updateEmail,
-        onUsernameChange = viewModel::updateUsername,
-        onPasswordChange = viewModel::updatePassword,
-        onConfirmPasswordChange = viewModel::updateConfirmPassword,
-        onSignUpClick = {viewModel.signUp()},
-        onSignInTxtClick = {onSignInTxtClick()},
-        onBackClick = onBackClick,
-        onSignUpSuccess = onSignUpSuccess,
-        modifier = modifier
-    )
-
     if (uiState.isSignUpSuccessful) {
         LaunchedEffect(Unit) {
             onSignUpSuccess()
         }
+    }else{
+        SignUpContent(
+            uiState = uiState,
+            onEmailChange = viewModel::updateEmail,
+            onUsernameChange = viewModel::updateUsername,
+            onPasswordChange = viewModel::updatePassword,
+            onConfirmPasswordChange = viewModel::updateConfirmPassword,
+            onSignUpClick = {viewModel.signUp()},
+            onSignInTxtClick = {onSignInTxtClick()},
+            onBackClick = onBackClick,
+            onSignUpSuccess = onSignUpSuccess,
+            modifier = modifier
+        )
     }
 }
 

--- a/app/src/main/java/com/example/photonest/ui/screens/signup/SignUpScreen.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signup/SignUpScreen.kt
@@ -44,6 +44,7 @@ fun SignUpScreen(
     modifier: Modifier = Modifier,
     viewModel: SignUpViewModel = viewModel(),
     onSignUpSuccess: () -> Unit,
+    onSignInTxtClick: () -> Unit,
     onBackClick: () -> Boolean,
 ) {
     val uiState by viewModel.uiState.collectAsState()
@@ -55,6 +56,7 @@ fun SignUpScreen(
         onPasswordChange = viewModel::updatePassword,
         onConfirmPasswordChange = viewModel::updateConfirmPassword,
         onSignUpClick = {viewModel.signUp()},
+        onSignInTxtClick = {onSignInTxtClick()},
         onBackClick = onBackClick,
         onSignUpSuccess = onSignUpSuccess,
         modifier = modifier
@@ -75,6 +77,7 @@ fun SignUpContent(
     onPasswordChange: (String) -> Unit,
     onConfirmPasswordChange: (String) -> Unit,
     onSignUpClick: () -> Unit,
+    onSignInTxtClick: () -> Unit,
     onBackClick: () -> Boolean,
     onSignUpSuccess: () -> Unit,
     modifier: Modifier = Modifier
@@ -184,7 +187,7 @@ fun SignUpContent(
         }
         item {
             AnnotatedText(
-                text1 = "If already have an account.", text2 = "Sign In",
+                text1 = "If already have an account.", text2 = "Sign In", onClickTxt2 = {onSignInTxtClick()},
                 modifier = Modifier.height(24.dp)
             )
         }

--- a/app/src/main/java/com/example/photonest/ui/screens/signup/SignUpViewModel.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/signup/SignUpViewModel.kt
@@ -67,13 +67,19 @@ class SignUpViewModel() : ViewModel() {
                 _uiState.update {
                     it.copy(
                         isLoading = false,
-                        error = e.message?: "An error occurred during sign up"
+                        error = e.message?: "An error occurred during sign up",
+                        showErrorDialog = true
                     )
                 }
             }
 
         }
     }
+
+    fun dismissErrorDialog() {
+        _uiState.update { it.copy(showErrorDialog = false) }
+    }
+
     fun resetError() {
         _uiState.update { it.copy(error = null) }
     }
@@ -114,5 +120,6 @@ data class SignUpUiState(
     val usernameError: String? = null,
     val emailError: String? = null,
     val passwordError: String? = null,
-    val confirmPasswordError: String? = null
+    val confirmPasswordError: String? = null,
+    val showErrorDialog: Boolean = false
 )


### PR DESCRIPTION
### Description
This PR implements the SignIn UI along with its ViewModel and integrates the SignIn screen into the app's navigation flow. Key features and changes include:

- **SignIn UI**: Designed the SignIn screen using Jetpack Compose with input fields for email and password.
- **ViewModel Integration**: Added a `SignInViewModel` to handle the state management for email, password, validation, and sign-in logic using Firebase Authentication.
- **Navigation**: Integrated the SignIn screen into the app's navigation flow, allowing seamless navigation between screens.
- **Error Handling**: Implemented support for showing errors using an alert dialog box, which triggers upon failed sign-in attempts or invalid input.

### Changes
- Added SignIn UI with ViewModel and validation logic.
- Implemented navigation from SignIn to other screens (e.g., OTP).
- Integrated error handling using a dialog box to display authentication errors.