### PR TITLE
Adds the bookmark screen

### DIFF
--- a/app/src/main/java/com/example/photonest/ui/navigation/AppNavigation.kt
+++ b/app/src/main/java/com/example/photonest/ui/navigation/AppNavigation.kt
@@ -27,6 +27,8 @@ import com.example.photonest.ui.screens.home.HomeScreenViewModel
 import com.example.photonest.ui.screens.MainScaffold
 import com.example.photonest.ui.screens.addpost.AddPostBottomSheet
 import com.example.photonest.ui.screens.addpost.AddPostViewModel
+import com.example.photonest.ui.screens.bookmarks.BookmarksScreen
+import com.example.photonest.ui.screens.bookmarks.BookmarksViewModel
 import com.example.photonest.ui.screens.explore.ExploreScreen
 import com.example.photonest.ui.screens.explore.ExploreViewModel
 import com.example.photonest.ui.screens.profile.ProfileScreen
@@ -202,21 +204,22 @@ private fun NavigationGraph(
             )
         }
 
-//        composable(AppDestinations.BOOKMARKS_ROUTE) {
-//            BookmarksScreen(
-//                onNavigateToPostDetail = { postId ->
+        composable(AppDestinations.BOOKMARKS_ROUTE) {
+            BookmarksScreen(
+                onNavigateToPostDetail = { postId ->
 //                    navController.navigate("post_detail/$postId")
-//                },
-//                onNavigateToProfile = { userId ->
-//                    navController.navigate("${AppDestinations.PROFILE_ROUTE}/$userId")
-//                },
-//                modifier = Modifier
-//                    .background(MaterialTheme.colorScheme.background)
-//                    .fillMaxSize()
-//                    .padding(horizontal = 16.dp),
-//                viewModel = hiltViewModel<BookmarksViewModel>()
-//            )
-//        }
+                },
+                onNavigateToProfile = { userId ->
+                    navController.navigate("${AppDestinations.PROFILE_ROUTE}/$userId")
+                },
+                modifier = Modifier
+                    .background(MaterialTheme.colorScheme.background)
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
+                viewModel = hiltViewModel<BookmarksViewModel>(),
+                onPostClick = {  }
+            )
+        }
 //
         composable(AppDestinations.PROFILE_ROUTE) {
             ProfileScreen(
@@ -237,7 +240,8 @@ private fun NavigationGraph(
 //                },
                 modifier = Modifier
                     .background(MaterialTheme.colorScheme.background)
-                    .fillMaxSize().padding(horizontal = 16.dp),
+                    .fillMaxSize()
+                    .padding(horizontal = 16.dp),
                 viewModel = hiltViewModel<ProfileViewModel>()
             )
         }

--- a/app/src/main/java/com/example/photonest/ui/screens/bookmarks/BookmarksScreen.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/bookmarks/BookmarksScreen.kt
@@ -1,0 +1,192 @@
+package com.example.photonest.ui.screens.bookmarks
+
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.staggeredgrid.LazyVerticalStaggeredGrid
+import androidx.compose.foundation.lazy.staggeredgrid.StaggeredGridCells
+import androidx.compose.foundation.lazy.staggeredgrid.items
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.BookmarkBorder
+import androidx.compose.material.icons.filled.GridView
+import androidx.compose.material.icons.filled.ViewList
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.example.photonest.data.model.Post
+import com.example.photonest.ui.components.MyAlertDialog
+import com.example.photonest.ui.screens.bookmarks.components.PostGridItem
+import com.example.photonest.ui.screens.bookmarks.model.BookmarksEvent
+import com.example.photonest.ui.screens.home.components.PostItem
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun BookmarksScreen(
+    onNavigateToPostDetail: (Int) -> Unit,
+    onNavigateToProfile: (Int) -> Unit,
+    onPostClick: (String) -> Unit = {},
+    viewModel: BookmarksViewModel = hiltViewModel(),
+    modifier: Modifier = Modifier
+) {
+    val uiState by viewModel.uiState.collectAsState()
+
+    // Handle error dialog
+    MyAlertDialog(
+        shouldShowDialog = uiState.showErrorDialog,
+        onDismissRequest = { viewModel.onEvent(BookmarksEvent.DismissErrorDialog) },
+        title = "Error",
+        text = uiState.error ?: "An unknown error occurred",
+        confirmButtonText = "OK",
+        onConfirmClick = { viewModel.onEvent(BookmarksEvent.DismissErrorDialog) }
+    )
+
+    Column(
+        modifier = modifier
+    ) {
+        // Header with title and view toggle
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(bottom = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = "Bookmarks",
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.Bold
+            )
+
+            Row {
+                IconButton(
+                    onClick = { viewModel.onEvent(BookmarksEvent.ToggleViewType) }
+                ) {
+                    Icon(
+                        imageVector = if (uiState.isGridView) Icons.Default.ViewList else Icons.Default.GridView,
+                        contentDescription = if (uiState.isGridView) "List view" else "Grid view"
+                    )
+                }
+            }
+        }
+
+
+        // Content
+        when {
+            uiState.isLoading -> {
+                Box(
+                    modifier = Modifier.fillMaxSize(),
+                    contentAlignment = Alignment.Center
+                ) {
+                    CircularProgressIndicator()
+                }
+            }
+
+            uiState.bookmarkedPosts.isEmpty() -> {
+                EmptyBookmarksContent()
+            }
+
+            else -> {
+                BookmarkedPostsContent(
+                    posts = uiState.bookmarkedPosts,
+                    isGridView = uiState.isGridView,
+                    onPostClick = onPostClick,
+                    onBookmarkToggle = { postId ->
+                        viewModel.onEvent(BookmarksEvent.ToggleBookmark(postId))
+                    },
+                    onLikeToggle = { postId ->
+                        viewModel.onEvent(BookmarksEvent.ToggleLike(postId))
+                    },
+                    modifier = Modifier.fillMaxSize()
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun EmptyBookmarksContent() {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(32.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.Center
+    ) {
+        Icon(
+            imageVector = Icons.Default.BookmarkBorder,
+            contentDescription = null,
+            modifier = Modifier.size(64.dp),
+            tint = MaterialTheme.colorScheme.outline
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = "No bookmarks yet",
+            style = MaterialTheme.typography.headlineSmall,
+            fontWeight = FontWeight.Medium,
+            textAlign = TextAlign.Center
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = "Start bookmarking posts you want to save for later",
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.outline,
+            textAlign = TextAlign.Center
+        )
+    }
+}
+
+@Composable
+private fun BookmarkedPostsContent(
+    posts: List<Post>,
+    isGridView: Boolean,
+    onPostClick: (String) -> Unit,
+    onBookmarkToggle: (String) -> Unit,
+    onLikeToggle: (String) -> Unit,
+    modifier: Modifier = Modifier
+) {
+    if (isGridView) {
+        LazyVerticalStaggeredGrid(
+            columns = StaggeredGridCells.Fixed(2),
+            verticalItemSpacing = 8.dp,
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(bottom = 16.dp),
+            modifier = modifier
+        ) {
+            items(posts) { post ->
+                PostGridItem(
+                    post = post,
+                    onClick = { onPostClick(post.id) },
+                    onBookmarkClick = { onBookmarkToggle(post.id) },
+                    modifier = Modifier.fillMaxWidth()
+                )
+            }
+        }
+    } else {
+        LazyColumn(
+            verticalArrangement = Arrangement.spacedBy(16.dp),
+            contentPadding = PaddingValues(bottom = 16.dp)
+        ) {
+            items(posts) { post ->
+                PostItem(
+                    post = post,
+                    onPostClick = { onPostClick(post.id) },
+                    onLikeClick = { onLikeToggle(post.id) },
+                    onCommentClick = { onPostClick(post.id) },
+                    onBookmarkClick = { onBookmarkToggle(post.id) },
+                    onShareClick = { /* Handle share */ },
+                    onUserClick = { /* Handle user click */ }
+                )
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/photonest/ui/screens/bookmarks/BookmarksViewModel.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/bookmarks/BookmarksViewModel.kt
@@ -1,0 +1,155 @@
+package com.example.photonest.ui.screens.bookmarks
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.example.photonest.core.utils.Resource
+import com.example.photonest.domain.repository.IPostRepository
+import com.example.photonest.ui.screens.bookmarks.model.BookmarksEvent
+import com.example.photonest.ui.screens.bookmarks.model.BookmarksUiState
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class BookmarksViewModel @Inject constructor(
+    private val postRepository: IPostRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(BookmarksUiState())
+    val uiState: StateFlow<BookmarksUiState> = _uiState.asStateFlow()
+
+    init {
+        loadBookmarkedPosts()
+    }
+
+    fun onEvent(event: BookmarksEvent) {
+        when (event) {
+            is BookmarksEvent.RefreshBookmarks -> {
+                loadBookmarkedPosts()
+            }
+            is BookmarksEvent.ToggleViewType -> {
+                _uiState.update { currentState ->
+                    currentState.copy(isGridView = !currentState.isGridView)
+                }
+            }
+            is BookmarksEvent.ToggleBookmark -> {
+                toggleBookmark(event.postId)
+            }
+            is BookmarksEvent.ToggleLike -> {
+                toggleLike(event.postId)
+            }
+            is BookmarksEvent.DismissErrorDialog -> {
+                _uiState.update { currentState ->
+                    currentState.copy(
+                        showErrorDialog = false,
+                        error = null
+                    )
+                }
+            }
+        }
+    }
+
+    private fun loadBookmarkedPosts() {
+        viewModelScope.launch {
+            _uiState.update { it.copy(isLoading = true, error = null) }
+
+            when (val result = postRepository.getBookmarkedPosts()) {
+                is Resource.Success -> {
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            isLoading = false,
+                            bookmarkedPosts = result.data ?: emptyList(),
+                            error = null
+                        )
+                    }
+                }
+                is Resource.Error -> {
+                    _uiState.update { currentState ->
+                        currentState.copy(
+                            isLoading = false,
+                            error = result.message ?: "Failed to load bookmarks",
+                            showErrorDialog = true
+                        )
+                    }
+                }
+                is Resource.Loading -> {
+                    _uiState.update { it.copy(isLoading = true) }
+                }
+            }
+        }
+    }
+
+    private fun toggleBookmark(postId: String) {
+        viewModelScope.launch {
+            val currentPost = _uiState.value.bookmarkedPosts.find { it.id == postId }
+            if (currentPost?.isBookmarked == true) {
+                // Remove from bookmarks
+                when (val result = postRepository.unbookmarkPost(postId)) {
+                    is Resource.Success -> {
+                        // Remove post from the list since it's no longer bookmarked
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                bookmarkedPosts = currentState.bookmarkedPosts.filter { it.id != postId }
+                            )
+                        }
+                    }
+                    is Resource.Error -> {
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                error = result.message ?: "Failed to remove bookmark",
+                                showErrorDialog = true
+                            )
+                        }
+                    }
+                    is Resource.Loading -> {}
+                }
+            }
+        }
+    }
+
+    private fun toggleLike(postId: String) {
+        viewModelScope.launch {
+            val currentPost = _uiState.value.bookmarkedPosts.find { it.id == postId }
+            if (currentPost != null) {
+                val result = if (currentPost.isLiked) {
+                    postRepository.unlikePost(postId)
+                } else {
+                    postRepository.likePost(postId)
+                }
+
+                when (result) {
+                    is Resource.Success -> {
+                        // Update the post in the list
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                bookmarkedPosts = currentState.bookmarkedPosts.map { post ->
+                                    if (post.id == postId) {
+                                        post.copy(
+                                            isLiked = !post.isLiked,
+                                            likeCount = if (post.isLiked) post.likeCount - 1 else post.likeCount + 1
+                                        )
+                                    } else {
+                                        post
+                                    }
+                                }
+                            )
+                        }
+                    }
+                    is Resource.Error -> {
+                        _uiState.update { currentState ->
+                            currentState.copy(
+                                error = result.message ?: "Failed to toggle like",
+                                showErrorDialog = true
+                            )
+                        }
+                    }
+                    is Resource.Loading -> {}
+                }
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/photonest/ui/screens/bookmarks/components/PostGridItem.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/bookmarks/components/PostGridItem.kt
@@ -1,0 +1,131 @@
+package com.example.photonest.ui.screens.bookmarks.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Bookmark
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.layout.layoutId
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import coil.compose.AsyncImage
+import com.example.photonest.R
+import com.example.photonest.data.model.Post
+
+@Composable
+fun PostGridItem(
+    post: Post,
+    onClick: () -> Unit,
+    onBookmarkClick: () -> Unit,
+    modifier: Modifier = Modifier
+) {
+    Card(
+        modifier = modifier
+            .clickable { onClick() },
+        shape = RoundedCornerShape(12.dp),
+        elevation = CardDefaults.cardElevation(defaultElevation = 8.dp)
+    ) {
+        Column {
+            // Image section
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .heightIn(max = 300.dp)
+            ) {
+                AsyncImage(
+                    model = post.imageUrl,
+                    contentDescription = null,
+                    modifier = Modifier
+                        .wrapContentSize()
+                        .clip(RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)),
+                    contentScale = ContentScale.FillWidth
+                )
+
+                IconButton(
+                    onClick = onBookmarkClick,
+                    modifier = Modifier.align(Alignment.TopEnd)
+                ) {
+                    Icon(
+                        painter = painterResource(
+                            id = if (post.isBookmarked) R.drawable.bookmark_icon_filled else R.drawable.bookmark_icon_outlined
+                        ),
+                        contentDescription = if (post.isBookmarked) "Bookmarked post" else "not a Bookmarked post",
+                        tint = if (post.isBookmarked)
+                            MaterialTheme.colorScheme.primary
+                        else
+                            MaterialTheme.colorScheme.outline,
+                        modifier = Modifier.size(20.dp)
+                    )
+                }
+
+//                // Bookmark icon
+//                IconButton(
+//                    onClick = onBookmarkClick,
+//                    modifier = Modifier.align(Alignment.TopEnd)
+//                ) {
+//                    Icon(
+//                        imageVector = Icons.Default.Bookmark,
+//                        contentDescription = "Bookmark",
+//                        tint = if (post.isBookmarked)
+//                            MaterialTheme.colorScheme.primary
+//                        else
+//                            MaterialTheme.colorScheme.outline
+//                    )
+//                }
+            }
+
+//            // Content section
+//            Column(
+//                modifier = Modifier
+//                    .fillMaxWidth()
+//                    .padding(12.dp)
+//            ) {
+//                Text(
+//                    text = post.caption,
+//                    style = MaterialTheme.typography.bodyMedium,
+//                    maxLines = 2,
+//                    overflow = TextOverflow.Ellipsis
+//                )
+//
+//                if (post.location.isNotEmpty()) {
+//                    Spacer(modifier = Modifier.height(4.dp))
+//                    Text(
+//                        text = post.location,
+//                        style = MaterialTheme.typography.bodySmall,
+//                        color = MaterialTheme.colorScheme.outline,
+//                        maxLines = 1,
+//                        overflow = TextOverflow.Ellipsis
+//                    )
+//                }
+//
+//                Spacer(modifier = Modifier.height(8.dp))
+//
+//                Row(
+//                    modifier = Modifier.fillMaxWidth(),
+//                    horizontalArrangement = Arrangement.SpaceBetween,
+//                    verticalAlignment = Alignment.CenterVertically
+//                ) {
+//                    Text(
+//                        text = "${post.likeCount} likes",
+//                        style = MaterialTheme.typography.bodySmall,
+//                        color = MaterialTheme.colorScheme.outline
+//                    )
+//
+//                    Text(
+//                        text = "${post.commentCount} comments",
+//                        style = MaterialTheme.typography.bodySmall,
+//                        color = MaterialTheme.colorScheme.outline
+//                    )
+//                }
+//            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/photonest/ui/screens/bookmarks/model/BookmarksUistate.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/bookmarks/model/BookmarksUistate.kt
@@ -1,0 +1,11 @@
+package com.example.photonest.ui.screens.bookmarks.model
+
+import com.example.photonest.data.model.Post
+
+data class BookmarksUiState(
+    val isLoading: Boolean = false,
+    val bookmarkedPosts: List<Post> = emptyList(),
+    val isGridView: Boolean = true,
+    val error: String? = null,
+    val showErrorDialog: Boolean = false
+)

--- a/app/src/main/java/com/example/photonest/ui/screens/bookmarks/model/BoookmarksEvent.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/bookmarks/model/BoookmarksEvent.kt
@@ -1,0 +1,9 @@
+package com.example.photonest.ui.screens.bookmarks.model
+
+sealed class BookmarksEvent {
+    object RefreshBookmarks : BookmarksEvent()
+    object ToggleViewType : BookmarksEvent()
+    data class ToggleBookmark(val postId: String) : BookmarksEvent()
+    data class ToggleLike(val postId: String) : BookmarksEvent()
+    object DismissErrorDialog : BookmarksEvent()
+}

--- a/app/src/main/java/com/example/photonest/ui/screens/home/components/PostItem.kt
+++ b/app/src/main/java/com/example/photonest/ui/screens/home/components/PostItem.kt
@@ -53,6 +53,8 @@ fun PostItem(
     onPostClick: () -> Unit,
     onLikeClick: () -> Unit,
     onBookmarkClick: () -> Unit,
+    onCommentClick: () -> Unit = {},
+    onShareClick: () -> Unit = {},
     onUserClick: () -> Unit
 ) {
     val constraintSet = ConstraintSet {
@@ -147,7 +149,7 @@ fun PostItem(
         ) {
             Icon(
                 painter = painterResource(
-                    id = if (post.isBookmarked) R.drawable.bookmark_icon_outlined else R.drawable.bookmark_icon_filled
+                    id = if (post.isBookmarked) R.drawable.bookmark_icon_filled else R.drawable.bookmark_icon_outlined
                 ),
                 contentDescription = if (post.isBookmarked) "Bookmarked post" else "not a Bookmarked post",
                 tint = MaterialTheme.colorScheme.onSurfaceVariant,
@@ -163,6 +165,8 @@ fun PostItem(
             isLiked = post.isLiked,
             onPostClick = onPostClick,
             onLikeClick = onLikeClick,
+            onCommentClick = onCommentClick,
+            onShareClick = onShareClick,
             caption = post.caption,
             location = post.location,
             commentCount = post.commentCount,


### PR DESCRIPTION
- Implemented bookmarks screen with the following features:
- Toggle between grid and list view of bookmarked posts
- Like and unlike posts directly from bookmarks
- Remove bookmarks by tapping bookmark icon
- Display empty state when no bookmarks
- Show loading and error states with dialogs
- Navigation to post details on tap
- Uses Material 3 components and responsive layout